### PR TITLE
Add adoption note and implementers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
-BPMN in Color Proposal
-=================================
+# BPMN in Color Specification
 
-This repository contains the BPMN in Color Proposal:
+The BPMN in Color Specification has been adopted by the members of the [OMG BPMN Model Interchange Working Group (BPMN MIWG)](http://www.omgwiki.org/bpmn-miwg/) in 2014 as the recommended way to interchange colors among BPMN modeling tools. It is also used in the official reference models of the [BPMN MIWG Test Suite](https://github.com/bpmn-miwg/bpmn-miwg-test-suite).
 
-- A "whitepaper"
-- The XSD schema
-- A sample BPMN file with colors
+This repository contains the following files:
+
+- [The specification](BPMN in COLOR.pdf)
+- [The XSD schema](BPMN in Color.xsd)
+- [A sample BPMN file with colors](BPMN In Color Sample.bpmn)
+
+## Implementers
+
+Tools that implement the specification include:
+
+- Itesoft BPMN+ Composer
+- itp-commerce Process Modeler for Microsoft Visio
+- Trisotech BPMN Modeler
+- Trisotech BPMN Visio Add in
+


### PR DESCRIPTION
The current wording creates the impression that BPMN in Color is just a proposal that never gained any vendor adoption. This pull request clarifies that the BPMN MIWG has adopted this specification in 2014 and also adds a list of implementers.