### PR TITLE
docs: fix links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ The BPMN in Color Specification has been adopted by the members of the [OMG BPMN
 
 This repository contains the following files:
 
-- [The specification](BPMN in COLOR.pdf)
-- [The XSD schema](BPMN in Color.xsd)
-- [A sample BPMN file with colors](BPMN In Color Sample.bpmn)
+- [The specification](./BPMN%20in%20COLOR.pdf)
+- [The XSD schema](./BPMN%20in%20Color.xsd)
+- [A sample BPMN file with colors](./BPMN%20In%20Color%20Sample.bpmn)
 
 ## Implementers
 


### PR DESCRIPTION
Since the file names in the links contain spaces, encode the spaces for the link resolution to work.


### Rendering on GitHub

before | now
---- | ----
![image](https://user-images.githubusercontent.com/27200110/226283916-6a12d831-7c33-4521-8ddc-8c2bb7d8ec20.png) | ![image](https://user-images.githubusercontent.com/27200110/226284039-86cd0496-c826-4998-a215-764a40a40f47.png)
